### PR TITLE
Join front-/back-end pathway data in Redux state

### DIFF
--- a/src/components/Header/AuthenticatedHeaderOption.js
+++ b/src/components/Header/AuthenticatedHeaderOption.js
@@ -23,6 +23,8 @@ import {
 import HeaderNavLink from "./HeaderNavlink";
 import SearchBar from "../SearchBar";
 import Tooltip from "@mui/material/Tooltip";
+import Message from "../common/Message";
+import { LEARN_KEY, MENU_ITEMS } from "./constant";
 
 const rolesLandingPages = {
   admin: PATHS.PARTNERS,
@@ -89,11 +91,8 @@ function AuthenticatedHeaderOption({
     dispatch(pathwayActions.getPathways());
   }, [dispatch]);
 
-  let pythonPathwayId;
-  pathway.data &&
-    pathway.data.pathways.forEach((pathway) => {
-      if (pathway.code === "PRGPYT") pythonPathwayId = pathway.id;
-    });
+  const pythonPathwayId =
+      pathway.data?.pathways.find((pathway) => pathway.code === "PRGPYT")?.id;
 
   const partnerGroupId = user.data.user.partner_group_id;
 
@@ -158,11 +157,13 @@ function AuthenticatedHeaderOption({
               }}
             >
               <MenuItem onClick={handleOpenLearn}>
-                <Typography variant="subtitle1">Learn</Typography>
+                <Typography variant="subtitle1">
+                  <Message constantKey={MENU_ITEMS[LEARN_KEY].msgKey} />
+                </Typography>
                 {learn ? <ExpandLessIcon /> : <ExpandMoreIcon />}
               </MenuItem>
               <DropDown
-                dropDown="Learn"
+                dropDown={LEARN_KEY}
                 indicator={learn}
                 handleClose={handleCloseLearn}
                 toggleDrawer={toggleDrawer}
@@ -170,7 +171,7 @@ function AuthenticatedHeaderOption({
 
               <HeaderNavLink
                 to={PATHS.NEWUSER_DASHBOARED}
-                text="Dashboard"
+                text={<Message constantKey="DASHBOARD" />}
                 toggleDrawer={toggleDrawer}
               />
               <HeaderNavLink
@@ -185,13 +186,13 @@ function AuthenticatedHeaderOption({
               }}
             >
               <MobileDropDown
-                Menu="Learn"
+                menuKey={LEARN_KEY}
                 handleClose={handleCloseLearn}
                 toggleDrawer={toggleDrawer}
               />
               <HeaderNavLink
                 to={PATHS.NEWUSER_DASHBOARED}
-                text="Dashboard"
+                text={<Message constantKey="DASHBOARD" />}
                 toggleDrawer={toggleDrawer}
               />
               <HeaderNavLink
@@ -248,12 +249,12 @@ function AuthenticatedHeaderOption({
               <>
                 <HeaderNavLink
                   to={PATHS.USER}
-                  text="Students"
+                  text={<Message constantKey="STUDENTS" />}
                   toggleDrawer={toggleDrawer}
                 />
                 <HeaderNavLink
                   to={PATHS.VOLUNTEER}
-                  text="Volunteers"
+                  text={<Message constantKey="VOLUNTEERS" />}
                   toggleDrawer={toggleDrawer}
                 />
                 <HeaderNavLink
@@ -264,7 +265,7 @@ function AuthenticatedHeaderOption({
                 {canSpecifyPartnerGroupId && (
                   <HeaderNavLink
                     to={`${PATHS.STATE}/${partnerGroupId}`}
-                    text="Dashboard"
+                    text={<Message constantKey="DASHBOARD" />}
                     toggleDrawer={toggleDrawer}
                   />
                 )}
@@ -291,7 +292,7 @@ function AuthenticatedHeaderOption({
                       ? `${PATHS.STATE}/${partnerGroupId}`
                       : `${PATHS.PARTNERS}/${partnerId}`
                   }
-                  text="Dashboard"
+                  text={<Message constantKey="DASHBOARD" />}
                   toggleDrawer={toggleDrawer}
                 />
               </>

--- a/src/components/Header/DropDown.js
+++ b/src/components/Header/DropDown.js
@@ -61,13 +61,13 @@ const students = {
     // },
 
     {
-      title: <MESSAGE constantKey="VOLUNTEER_WITH_US" />,
+      title: <Message constantKey="VOLUNTEER_WITH_US" />,
       path: PATHS.VOLUNTEER_AUTOMATION,
       type: "internal",
     },
 
     {
-      title: <MESSAGE constantKey="DONATE" />,
+      title: <Message constantKey="DONATE" />,
       path: "https://www.navgurukul.org/donate",
       type: "external",
     },

--- a/src/components/Header/DropDown.js
+++ b/src/components/Header/DropDown.js
@@ -14,6 +14,7 @@ import { actions as pathwayActions } from "../PathwayCourse/redux/action";
 import ExternalLink from "../common/ExternalLink";
 import LaunchIcon from "@mui/icons-material/Launch";
 import Message from "../common/Message";
+import { LEARN_KEY, ABOUT_KEY, GET_INVOLVED_KEY, MENU_ITEMS } from "./constant";
 // import { useContext } from "react";
 // import { useLanguageConstants, getTranslationKey } from "../../common/language";
 // import { LanguageProvider } from "../../common/context";
@@ -31,7 +32,7 @@ import {
 
 const students = {
   image: [python, typing, language, web, residential, random],
-  Learn: [
+  [LEARN_KEY]: [
     { title: "Python", code: "PRGPYT", type: "internal" },
     { title: "Typing", code: "TYPGRU", type: "internal" },
     { title: "English", code: "SPKENG", type: "internal" },
@@ -48,11 +49,11 @@ const students = {
       type: "internal",
     },
   ],
-  About: [
+  [ABOUT_KEY]: [
     { title: "Our Story", path: PATHS.OUR_STORY, type: "internal" },
     { title: "Meraki Team", path: PATHS.TEAM, type: "internal" },
   ],
-  GetInvolved: [
+  [GET_INVOLVED_KEY]: [
     // {
     //   title: "Become a Partner",
     //   path: PATHS.OUR_PARTNER,
@@ -60,13 +61,13 @@ const students = {
     // },
 
     {
-      title: "Volunteer with Us",
+      title: <MESSAGE constantKey="VOLUNTEER_WITH_US" />,
       path: PATHS.VOLUNTEER_AUTOMATION,
       type: "internal",
     },
 
     {
-      title: "Donate",
+      title: <MESSAGE constantKey="DONATE" />,
       path: "https://www.navgurukul.org/donate",
       type: "external",
     },
@@ -78,7 +79,7 @@ const students = {
   ],
 };
 
-export const MobileDropDown = ({ Menu, handleClose, toggleDrawer }) => {
+export const MobileDropDown = ({ menuKey, handleClose, toggleDrawer }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const { data } = useSelector((state) => state.Pathways);
@@ -88,6 +89,7 @@ export const MobileDropDown = ({ Menu, handleClose, toggleDrawer }) => {
     dispatch(pathwayActions.getPathways());
   }, [dispatch]);
 
+/*
   data &&
     data.pathways &&
     data.pathways.forEach((pathway) => {
@@ -97,7 +99,7 @@ export const MobileDropDown = ({ Menu, handleClose, toggleDrawer }) => {
         }
       });
     });
-
+*/
   return (
     <Accordion elevation={0} sx={{ bgcolor: "#e9f5e9" }}>
       <AccordionSummary
@@ -108,11 +110,11 @@ export const MobileDropDown = ({ Menu, handleClose, toggleDrawer }) => {
       >
         <Typography variant="subtitle1">
           {/*MSG[getTranslationKey(Menu)]*/}
-          <Message>{Menu}</Message>
+          <Message constantKey={MENU_ITEMS[menuKey].msgKey} />
         </Typography>
       </AccordionSummary>
       <AccordionDetails>
-        {students[Menu.split(" ").join("")].map((menu, index) => {
+        {students[menuKey].map((menu, index) => {
           if (menu.type === "internal") {
             return (
               <Link
@@ -127,7 +129,7 @@ export const MobileDropDown = ({ Menu, handleClose, toggleDrawer }) => {
                 onClick={toggleDrawer && toggleDrawer(false)}
               >
                 <MenuItem key={index} onClick={handleClose}>
-                  {Menu === "Learn" && (
+                  {menuKey === LEARN_KEY && (
                     <img src={students.image[index]} alt="course logo" />
                   )}
                   <CardContent>
@@ -146,7 +148,7 @@ export const MobileDropDown = ({ Menu, handleClose, toggleDrawer }) => {
                 onClick={toggleDrawer && toggleDrawer(false)}
               >
                 <MenuItem key={index} onClick={handleClose}>
-                  {Menu === "Learn" && (
+                  {menuKey === LEARN_KEY && (
                     <img src={students.image[index]} alt="course logo" />
                   )}
                   <CardContent>
@@ -179,6 +181,7 @@ export const DropDown = ({
     dispatch(pathwayActions.getPathways());
   }, [dispatch]);
 
+/*
   data &&
     data.pathways &&
     data.pathways.forEach((pathway) => {
@@ -188,6 +191,7 @@ export const DropDown = ({
         }
       });
     });
+*/
 
   return (
     <Menu
@@ -227,22 +231,22 @@ export const DropDown = ({
                     onClick={handleClose}
                     sx={{
                       padding:
-                        dropDown === "Learn" ? "30px 6px 30px 6px" : "10px",
+                        dropDown === LEARN_KEY ? "30px 6px 30px 6px" : "10px",
                       margin: "6px 16px 6px 16px",
                     }}
                   >
-                    {dropDown === "Learn" && (
+                    {dropDown === LEARN_KEY && (
                       <img src={students.image[index]} alt="course logo" />
                     )}
                     <Typography
                       textAlign="center"
-                      sx={{ paddingLeft: dropDown === "Learn" && 2 }}
+                      sx={{ paddingLeft: dropDown === LEARN_KEY && 2 }}
                     >
                       {menu.title}
                     </Typography>
                   </MenuItem>
                 </Link>
-                {dropDown === "Learn" && index == 4 && <Divider />}
+                {dropDown === LEARN_KEY && index == 4 && <Divider />}
               </>
             );
           } else {
@@ -258,11 +262,11 @@ export const DropDown = ({
                     onClick={handleClose}
                     sx={{
                       padding:
-                        dropDown === "Learn" ? "30px 6px 30px 6px" : "10px",
+                        dropDown === LEARN_KEY ? "30px 6px 30px 6px" : "10px",
                       margin: "6px 16px 6px 16px",
                     }}
                   >
-                    {dropDown === "Learn" && (
+                    {dropDown === LEARN_KEY && (
                       <img src={students.image[index]} alt="course logo" />
                     )}
                     <Typography textAlign="center" sx={{ paddingRight: 1 }}>
@@ -271,7 +275,7 @@ export const DropDown = ({
                     <LaunchIcon />
                   </MenuItem>
                 </ExternalLink>
-                {dropDown === "Learn" && index == 4 && <Divider />}
+                {dropDown === LEARN_KEY && index == 4 && <Divider />}
               </>
             );
           }

--- a/src/components/Header/constant.js
+++ b/src/components/Header/constant.js
@@ -1,0 +1,32 @@
+export const LEARN_KEY = 'LEARN';
+export const ABOUT_KEY = 'ABOUT';
+export const GET_INVOLVED_KEY = 'GET_INVOLVED';
+
+export const MENU_ITEMS = {
+  [LEARN_KEY]: {
+    msgKey: LEARN_KEY,
+  },
+  [ABOUT_KEY]: {
+    msgKey: ABOUT_KEY,
+  },
+  [GET_INVOLVED_KEY]: {
+    msgKey: GET_INVOLVED_KEY,
+  },
+}
+
+// Mapping from menu item keys to the MSG string keys for their text
+//     For now we'll use the identity (e.g., MENU_MSG_KEY_MAP.ABOUT = 'ABOUT'),
+//     but this map will allow flexibility if we wanted to change the MSG key
+//     to say HEADER_ABOUT, reserving the ABOUT MSG key for 'about' appearing
+//     in a paragraph.
+export const MENU_MSG_KEY_MAP = {
+  [LEARN_KEY]: LEARN_KEY,
+  [ABOUT_KEY]: ABOUT_KEY,
+  [GET_INVOLVED_KEY]: GET_INVOLVED_KEY,
+  // Learn: 'LEARN',
+  // About: 'ABOUT',
+  // GetInvolved: 'GET_INVOLVED',
+};
+
+export const PUBLIC_MENU_KEYS = [LEARN_KEY, ABOUT_KEY, GET_INVOLVED_KEY];
+// export const PUBLIC_MENU_KEYS = ["LEARN", "ABOUT", "GET_INVOLVED"];

--- a/src/components/Header/constant.js
+++ b/src/components/Header/constant.js
@@ -12,7 +12,7 @@ export const MENU_ITEMS = {
   [GET_INVOLVED_KEY]: {
     msgKey: GET_INVOLVED_KEY,
   },
-}
+};
 
 // Mapping from menu item keys to the MSG string keys for their text
 //     For now we'll use the identity (e.g., MENU_MSG_KEY_MAP.ABOUT = 'ABOUT'),

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -44,10 +44,10 @@ const PublicMenuOption = ({ leftDrawer, toggleDrawer, handleSearchChange }) => {
   const classes = useStyles();
   // const { language, MSG } = useLanguageConstants(); //useContext(LanguageProvider);
 
-  const menuOpenHandler = (event, menu) => {
+  const menuOpenHandler = (event, menuKey) => {
     setIndicator(event.currentTarget);
-    setDropDownMenu(menu.split(" ").join(""));
-    SetSelectedMenu(menu);
+    setDropDownMenu(menuKey);
+    SetSelectedMenu(menuKey);
   };
 
   const showLoginButton = !useRouteMatch({
@@ -65,7 +65,7 @@ const PublicMenuOption = ({ leftDrawer, toggleDrawer, handleSearchChange }) => {
           <>
             <MenuItem
               onClick={(e) => {
-                menuOpenHandler(e, menu);
+                menuOpenHandler(e, menuKey);
               }}
               sx={{ color: "black" }}
               key={index}
@@ -74,7 +74,7 @@ const PublicMenuOption = ({ leftDrawer, toggleDrawer, handleSearchChange }) => {
                 {/*MSG[getTranslationKey(menu)]*/}
                 <Message constantKey={MENU_ITEMS[menuKey].msgKey} />
               </Typography>
-              {selectedMenu === menu && indicator ? (
+              {selectedMenu === menuKey && indicator ? (
                 <ExpandLessIcon />
               ) : (
                 <ExpandMoreIcon />

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -32,6 +32,7 @@ import SearchBar from "../SearchBar";
 import { useHistory } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import Message from "../common/Message";
+import { PUBLIC_MENU_KEYS, MENU_ITEMS } from "./constant";
 // import { useContext } from "react";
 // import { useLanguageConstants, getTranslationKey } from "../../common/language";
 // import { LanguageProvider } from "../../common/context";
@@ -60,7 +61,7 @@ const PublicMenuOption = ({ leftDrawer, toggleDrawer, handleSearchChange }) => {
   return (
     <>
       <Box sx={{ flexGrow: 1, display: { xs: "none", md: "flex" } }}>
-        {["Learn", "About", "Get Involved"].map((menu, index) => (
+        {PUBLIC_MENU_KEYS.map((menuKey, index) => (
           <>
             <MenuItem
               onClick={(e) => {
@@ -71,7 +72,7 @@ const PublicMenuOption = ({ leftDrawer, toggleDrawer, handleSearchChange }) => {
             >
               <Typography variant="subtitle1">
                 {/*MSG[getTranslationKey(menu)]*/}
-                <Message>{menu}</Message>
+                <Message constantKey={MENU_ITEMS[menuKey].msgKey} />
               </Typography>
               {selectedMenu === menu && indicator ? (
                 <ExpandLessIcon />
@@ -89,9 +90,9 @@ const PublicMenuOption = ({ leftDrawer, toggleDrawer, handleSearchChange }) => {
         ))}
       </Box>
       <Box sx={{ flexGrow: 1, display: { xs: leftDrawer ? "block" : "none" } }}>
-        {["Learn", "About", "Get Involved"].map((Menu) => (
+        {PUBLIC_MENU_KEYS.map((menuKey) => (
           <MobileDropDown
-            Menu={Menu}
+            menuKey={menuKey}
             handleClose={menuCloseHandler}
             toggleDrawer={toggleDrawer}
           />

--- a/src/components/PathwayCourse/redux/api.js
+++ b/src/components/PathwayCourse/redux/api.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { METHODS } from "../../../services/api";
-import { versionCode } from "../../../constant";
+import { versionCode, PATHWAYS_INFO } from "../../../constant";
 
 export const getPathways = () => {
   return axios({
@@ -10,6 +10,39 @@ export const getPathways = () => {
       "version-code": versionCode,
     },
     // headers: HeaderFactory(token),
+  }).then((response) => {
+    if (!response?.data?.pathways) {
+      return response;
+    }
+    // Augment pathways data from back-end with new data to simulate it all
+    //     coming from the back-end
+    // quick way to copy exported constant since it's being modified
+    const frontEndPathwayData = JSON.parse(JSON.stringify(PATHWAYS_INFO));
+    const backEndPathwayData = response?.data?.pathways || [];
+    const feCodeToIndexMap = frontEndPathwayData.reduce(
+      (codeMap, pathway, index) => {
+        if (pathway.code) {
+          codeMap[pathway.code] = index;
+        }
+        return codeMap;
+      },
+      {}
+    );
+
+    response.data.pathways = backEndPathwayData.reduce((pathwayData, pathway) => {
+      const indexOfPathway = feCodeToIndexMap[pathway.code];
+      if (indexOfPathway != undefined) {
+        pathwayData[indexOfPathway] = {
+          ...pathway,
+          ...pathwayData[indexOfPathway],
+        };
+      } else {
+        pathwayData.push(pathway);
+      }
+      return pathwayData;
+    }, frontEndPathwayData);
+
+    return response;
   });
 };
 

--- a/src/components/common/Message/index.js
+++ b/src/components/common/Message/index.js
@@ -1,9 +1,9 @@
 import { useLanguageConstants, getTranslationKey } from "../../../common/language";
 
-function Message({ constantName, children }) {
+function Message({ constantKey, children }) {
   const { language, MSG } = useLanguageConstants();
-  if (constantName) {
-    return MSG[constantName];
+  if (constantKey) {
+    return MSG[constantKey];
   } else {
     const key = getTranslationKey(children);
     return key ? MSG[key] : children;

--- a/src/constant.js
+++ b/src/constant.js
@@ -113,7 +113,7 @@ export const PATHWAYS_INFO = [
     type: "internal",
     link: PATHS.MISCELLANEOUS_COURSE,
   },
-],
+];
 
 /*
 export const dateTimeFormat = (date) => {

--- a/src/constant.js
+++ b/src/constant.js
@@ -49,6 +49,72 @@ export const HideFooter = [
   PATHS.VOLUNTEER_FORM,
 ];
 
+export const PATHWAYS_INFO = [
+  {
+    title: "Python",
+    code: "PRGPYT",
+    image: "python",
+    video_link: "https://youtu.be/DDFvJmC3J5M",
+    description: "Get familiar with programming with bite sized lessons",
+    outcomes: [
+      "Get equipped to build small projects like calculator or to-do list",
+      "Get the base knowledge to apply to advanced bootcamps such as Navgurukul or Zoho Schools",
+    ],
+    type: "internal",
+  },
+  {
+    title: "Typing",
+    code: "TYPGRU",
+    video_link: "https://youtu.be/HQ9IYtBJO0U",
+    image: "typing",
+    description: "Learn to type with pinpoint accuracy and speed.",
+    outcomes: [
+      "Reach a typing speed of up to 30 to 40 words per minute",
+      "Be able to type long text with minimal inaccuracies",
+    ],
+    type: "internal",
+  },
+  {
+    title: "Spoken English", // or English (DropDown.js)
+    code: "SPKENG",
+    image: "language",
+    video_link: "https://youtu.be/g05oD3i67_A",
+    description: "Master English with easy to understand courses",
+    outcomes: [
+      "Start speaking English without fear in about 6 months",
+      "Be able to read, write, listen and speak English with fluency",
+      "Be able to give oral presentations, talk to friends and prospective colleagues",
+    ],
+    type: "internal",
+  },
+  {
+    title: "JavaScript", // "Web Development" (New User Dashboard)
+    code: "JSRPIT",
+    image: "web-development",
+    video_link: "https://youtu.be/EC7UaTE9Z2Q",
+    description: "Learn the basics of tech that powers the web",
+    outcomes: [
+      "Build your first web page and power it with the interactive language of Javascript",
+      "Build your basics of HTML, CSS and Javascript to prepare for advanced web development courses",
+    ],
+    type: "internal",
+  },
+  {
+    title: "Residential Programmes",
+    image: "residential",
+    description: "Explore Navgurukul’s on campus Software Engineering courses",
+    type: "internal",
+    link: PATHS.RESIDENTIAL_COURSE,
+  },
+  {
+    title: "Open Courses", // or Miscellaneous Courses (Dropdown, Footer)
+    image: "misc",
+    description: "Courses on Android, Game dev projects and more",
+    type: "internal",
+    link: PATHS.MISCELLANEOUS_COURSE,
+  },
+],
+
 /*
 export const dateTimeFormat = (date) => {
   try {

--- a/src/msg/en.js
+++ b/src/msg/en.js
@@ -2,6 +2,13 @@ const en = {};
 en.LEARN = "Learn";
 en.ABOUT = "About";
 en.GET_INVOLVED = "Get Involved";
+en.OUR_STORY = "Our Story";
+en.DASHBOARD = "Dashboard";
+en.STUDENT = "Student";
+en.VOLUNTEER = "Volunteer";
+en.DONATE = "Donate";
+en.STUDENTS = "Students";
+en.VOLUNTEERS = "Volunteers";
 en.VOLUNTEER_WITH_US = "Volunteer with Us";
 
 export default en;

--- a/src/msg/hi.js
+++ b/src/msg/hi.js
@@ -2,6 +2,13 @@ const hi = {};
 hi.LEARN = "सीखें";
 hi.ABOUT = "के बारे में";
 hi.GET_INVOLVED = "उलझना";
+hi.OUR_STORY = "हमारी कहानी";
+hi.DASHBOARD = "डैशबोर्ड";
+hi.STUDENT = "छात्र";
+hi.VOLUNTEER = "स्वयंसेवक";
+hi.STUDENTS = "छात्र";
+hi.VOLUNTEERS = "स्वयंसेवक";
+hi.DONATE = "दान करें";
 hi.VOLUNTEER_WITH_US = "हमारे साथ स्वयंसेवक करें";
 
 export default hi;


### PR DESCRIPTION
* Move all front-end pathway data to constant file.
* Have the `getPathways` function that makes the API request to get the pathway data join the response from the back-end and front-end pathway data so that it looks as if the joined data came exclusively from the back-end when a `GET_PATHWAY_INTENT` action is dispatched to the Redux store.
* Add constant file in the Header directory, which includes menu keys and their mapping to message key strings.  Use these menu keys instead of hard-coded strings in Header components.
* Add English/Hindi message strings for menu items.

**Which issue does this refer to ?**
A clear and concise description. Use `#` to refer to github issues and PR

**Brief description of the changes done**
A brief step by step changes made. Example :
1. Upgraded packages
2. Added extra state to handle clicks
3. ...

**People to loop in / review from**
Use `@` key to tag people to review from